### PR TITLE
bugfix: Missing key in inventory summary api

### DIFF
--- a/codeinsight_sdk/__init__.py
+++ b/codeinsight_sdk/__init__.py
@@ -1,1 +1,18 @@
+#  _  _   _   _ ___       __ ___  __    ___    __  _
+# /  / \ | \ |_  |  |\ | (_   |  /__ |_| | __ (_  | \ |/
+# \_ \_/ |_/ |_ _|_ | \| __) _|_ \_| | | |    __) |_/ |\
+#
+"""
+Code Insight SDK package for Python.
+
+Copyright (C) 2024 Zachary Karpinski. All Rights Reserved.
+
+Basic usage:
+
+   >>> import codeinsight_sdk
+   >>> client = codeinsight_sdk.CodeInsightClient(<base_url>, <api_token>)
+   >>> print(client.projects.all())
+   ...
+"""
+
 from .client import CodeInsightClient

--- a/codeinsight_sdk/models.py
+++ b/codeinsight_sdk/models.py
@@ -38,8 +38,8 @@ class ProjectInventoryItem(DataClassJsonMixin):
     type: str
     priority: str
     createdBy: str
-    createdOn: str
-    updatedOn: str
+    createdOn: Optional[str] = None
+    updatedOn: Optional[str] = None
     url: Optional[str] = None
     componentUrl: Optional[str] = None
     componentDescription: Optional[str] = None

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -176,8 +176,6 @@ class TestProjectEndpoints:
                 "type":"component",
                 "priority":"low",
                 "createdBy":"Zach",
-                "createdOn":"Today",
-                "updatedOn":"Tomorrow",
                 "componentName":"snakeyaml",
                 "componentVersionName":"2.0"
             },
@@ -188,8 +186,6 @@ class TestProjectEndpoints:
                 "type":"component",
                 "priority":"low",
                 "createdBy":"Zach",
-                "createdOn":"Today",
-                "updatedOn":"Tomorrow",
                 "componentName":"snakeyaml",
                 "componentVersionName":"2.0"
             }


### PR DESCRIPTION
Inventory Summary API doesn't return createdDate and UpdateDate. Updated model and tests